### PR TITLE
Changed behavior of fetch agent

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "spotify-url-info",
   "description": "Get metadata from Spotify URLs",
   "homepage": "https://github.com/microlinkhq/spotify-url-info",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "main": "src/index.js",
   "author": {
     "email": "kall@kall.ws",

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ const createGetData = fetch => async (url, opts) => {
   const embedURL = spotifyURI.formatEmbedURL(parsedUrl)
 
   const response = await fetch(embedURL, opts)
-  const text = await response.text()
+  const text = response.text ? await response.text() : response.data
   const embed = parse(text)
 
   const scripts = embed


### PR DESCRIPTION
Not every fetch agent has `.text()` function - now it works with axios.